### PR TITLE
Added an entry about installing ones own plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ $ yarn start
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
+**NB:** The page defaults to the last version, your local changes will only be visble after selecting `nightly` in the navbar.
+
 ### Build
 
 ```

--- a/docs/Configuration/adding_own_plugins.md
+++ b/docs/Configuration/adding_own_plugins.md
@@ -1,0 +1,46 @@
+---
+id: adding_own_plugins
+title: Adding your own plugins
+---
+
+## Create your own config file(s)
+First off, for a comprehensive explanation of how best to manage your local configuration files see: [Managing user config](/Configuration/manage_user_config)
+
+However if you're not familiar with Packer, neovim, lua or Astrovim here is the short version of how to add packages:
+
+Create the file`~/.config/nvim/lua/user/init.lua`
+
+and add the following contents 
+
+```
+local config = {
+  plugins = {
+    init = {
+      { "tpope/vim-fugitive" },
+      { "tpope/vim-surround" },
+    },
+}
+
+return config
+```
+
+Then restart vim and type `<leader>` + p (for Packer, you should see it in the menu that appears) then `s` for "sync".
+This runs Packer Sync, which is the command that installs and enables (or disables / removes when desired) packages
+
+## To disable an AstroVim package
+
+Within your `user/init.lua` file above add to the `init` block like so:
+
+```
+local config = {
+  plugins = {
+    init = {
+      ["declancm/cinnamon.nvim"] = { disable = true },
+      { "tpope/vim-fugitive" },
+      { "tpope/vim-surround" },
+    },
+}
+
+return config
+```
+Above we disable the cinnamon plugin by way of example


### PR DESCRIPTION
I found myself really struggling with the current documentation (after having used AstroVim briefly last year) and coming back to it, trying to remember how to install my own plugins. I think the lack of a clear entry about this over made it difficult to pick apart what was required.

This might be too basic, or require some re-wording but I was almost ready to throw in the towel myself, and think it would be a shame to lose new users who give up too quickly looking for this info. Hope it's of some minor use.

(Also added a clarifying remark about a gotcha I had while running these docs locally)

@mehalter I'm not sure if you get a notification when I create these, but I can't assign anyone so tagging you on this first one to find out (working on another PR)