### PR TITLE
Fixed bug where alpha_on_bye would error if windows were open when you closed the last buffer.

### DIFF
--- a/docs/Recipes/alpha.md
+++ b/docs/Recipes/alpha.md
@@ -25,7 +25,13 @@ return {
   polish = function()
     local function alpha_on_bye(cmd)
       local bufs = vim.fn.getbufinfo { buflisted = true }
-      vim.cmd(cmd)
+      local wins = vim.fn.winnr "$"
+      if wins > 1 and not bufs[2] then
+        vim.cmd(cmd)
+        vim.cmd [[silent only]]
+      else
+        vim.cmd(cmd)
+      end
       if require("core.utils").is_available "alpha-nvim" and not bufs[2] then
         require("alpha").start(true)
       end


### PR DESCRIPTION
Added wins var.
Added if else to check if window count > 1.
if then also calls vim.cmd[[silent only]] when closing the last buffer.
else functions as before changes.

To recreate the bug, enable alpha_on_bye and then open splits and close all buffers when closing the last buffer all splits will attempt alpha_on_bye, and error messages appear in the command line. It then becomes difficult to close all the windows, and the best solution is to restart the session.