### PR TITLE
Fixed typo in disable_tabline.md in docs/Recipes/disable_tabline.md

### DIFF
--- a/docs/Recipes/disable_tabline.md
+++ b/docs/Recipes/disable_tabline.md
@@ -3,7 +3,7 @@ id: disable_tabline
 title: Disable Tabline
 ---
 
-By default AstroNvim uses Heirline for generating the tabline for displaying buffers as tabls. Some users may not like this behavior and prefer to not have the bar at the top. You can do this a couple ways. The easiest would be to set `vim.opt.showtabline` to `0` which will hide the bar but still let it be toggled in the UI as well as let the interactive buffer picker with `<leader>b` to function when necessary.
+By default AstroNvim uses Heirline for generating the tabline for displaying buffers as tabs. Some users may not like this behavior and prefer to not have the bar at the top. You can do this a couple ways. The easiest would be to set `vim.opt.showtabline` to `0` which will hide the bar but still let it be toggled in the UI as well as let the interactive buffer picker with `<leader>b` to function when necessary.
 
 ```lua
 return {


### PR DESCRIPTION
Fixed small typo. I suppose it could also be trying to say tables but I think this is correct.