### PR TITLE
Fixed more typos in Recipes/cmp.md

### DIFF
--- a/docs/Recipes/cmp.md
+++ b/docs/Recipes/cmp.md
@@ -35,7 +35,7 @@ Similarly to customizing mappings, you can customize and configure your `cmp` so
 ```lua
 return {
   plugins = {
-    { -- override nvim-autopairs plugin
+    { -- override nvim-cmp plugin
       "hrsh7th/nvim-cmp",
       -- override the options table that is used in the `require("cmp").setup()` call
       opts = function(_, opts)
@@ -65,7 +65,7 @@ You can use this `cmp` override to also customize the options of the sources:
 ```lua
 return {
   plugins = {
-    { -- override nvim-autopairs plugin
+    { -- override nvim-cmp plugin
       "hrsh7th/nvim-cmp",
       -- override the options table that is used in the `require("cmp").setup()` call
       opts = function(_, opts)
@@ -101,7 +101,7 @@ To add more sources than the default, you can add other `cmp` source plugins as 
 ```lua
 return {
   plugins = {
-    { -- override nvim-autopairs plugin
+    { -- override nvim-cmp plugin
       "hrsh7th/nvim-cmp",
       dependencies = {
         "hrsh7th/cmp-emoji", -- add cmp source as dependency of cmp
@@ -136,7 +136,7 @@ You can also use the `config` function and the provided default configuration fu
 return {
   plugins = {
     {
-      { -- override nvim-autopairs plugin
+      { -- override nvim-cmp plugin
         "hrsh7th/nvim-cmp",
         keys = { ":", "/", "?" }, -- lazy load cmp on more keys along with insert mode
         dependencies = {

--- a/docs/Recipes/disable_tabline.md
+++ b/docs/Recipes/disable_tabline.md
@@ -3,7 +3,7 @@ id: disable_tabline
 title: Disable Tabline
 ---
 
-By default AstroNvim uses Heirline for generating the tabline for displaying buffers as tabls. Some users may not like this behavior and prefer to not have the bar at the top. You can do this a couple ways. The easiest would be to set `vim.opt.showtabline` to `0` which will hide the bar but still let it be toggled in the UI as well as let the interactive buffer picker with `<leader>b` to function when necessary.
+By default AstroNvim uses Heirline for generating the tabline for displaying buffers as tabs. Some users may not like this behavior and prefer to not have the bar at the top. You can do this a couple ways. The easiest would be to set `vim.opt.showtabline` to `0` which will hide the bar but still let it be toggled in the UI as well as let the interactive buffer picker with `<leader>b` to function when necessary.
 
 ```lua
 return {


### PR DESCRIPTION
Fixed a few typos in Recipes/cmp.md where autopairs was mentioned in comments instead of nvim-cmp.

this is ontop of my previous commit, also fixing typos.