### PR TITLE
Removed no longer available black belt config

### DIFF
--- a/docs/Recipes/black_belt.md
+++ b/docs/Recipes/black_belt.md
@@ -10,5 +10,4 @@ This is a collection of advanced fully complete AstroNvim user configurations fo
 - [kabinspace](https://github.com/kabinspace/AstroNvim_user)
 - [datamonsterr](https://github.com/datamonsterr/astronvim_config)
 - [hunger](https://github.com/hunger/AstroVim/tree/my_config/lua/user)
-- [thieung](https://github.com/thieung/dotfiles/tree/main/config/nvim)
 - [A-Lamia](https://github.com/A-Lamia/AstroNvim-conf)


### PR DESCRIPTION
Hi guys! 👋🏻

Sadly I found out https://github.com/thieung/dotfiles/tree/main/config/nvim is not available and it appears there's no nvim config in the new folder available at https://github.com/thieung/dotfiles/tree/main/dot_config.

At first I thought about pointing to a previous commit, but sounds like the repo has been reset and has only one commit.