### PR TITLE
Fix typos in colorscheme.md and custom_plugins.md

### DIFF
--- a/docs/Recipes/colorscheme.md
+++ b/docs/Recipes/colorscheme.md
@@ -14,7 +14,7 @@ return {
   plugins = {
     {
       "catppuccin/nvim",
-      as = "catppuccin",
+      name = "catppuccin",
       config = function()
         require("catppuccin").setup {}
       end,

--- a/docs/Recipes/custom_plugins.md
+++ b/docs/Recipes/custom_plugins.md
@@ -115,7 +115,7 @@ return {
   plugins = {
     {
       "catppuccin/nvim",
-      as = "catppuccin",
+      name = "catppuccin",
       config = function()
         require("catppuccin").setup {}
       end,
@@ -136,7 +136,7 @@ With Lazy.nvim the name of the file in the `plugins/` folder can be anything, so
 return {
   {
     "catppuccin/nvim",
-    as = "catppuccin",
+    name = "catppuccin",
     config = function()
       require("catppuccin").setup {}
     end,


### PR DESCRIPTION
Fix typos that were using the old packer.nvim field names (`as`) to use the lazy.nvim names (`name`)