### PR TITLE
docs: add ToggleTerm `Ctrl + '` mapping

### DIFF
--- a/docs/Basic Usage/mappings.md
+++ b/docs/Basic Usage/mappings.md
@@ -160,7 +160,7 @@ title: Default Mappings
 
 | Action                    | Mappings                     |
 | ------------------------- | ---------------------------- |
-| Toggle Terminal           | `F7`                         |
+| Toggle Terminal           | `F7`, `Ctrl + '`             |
 | Floating Terminal         | `Leader + tf`                |
 | Horizontal Split Terminal | `Leader + th`                |
 | Vertical Split Terminal   | `Leader + tv`                |

--- a/versioned_docs/version-2.10.0/Basic Usage/mappings.md
+++ b/versioned_docs/version-2.10.0/Basic Usage/mappings.md
@@ -149,7 +149,7 @@ title: Default Mappings
 
 | Action                    | Mappings                   |
 | ------------------------- | -------------------------- |
-| Toggle Terminal           | `F7`                       |
+| Toggle Terminal           | `F7`, `Ctrl + '`           |
 | Floating Terminal         | `Space + tf`               |
 | Horizontal Split Terminal | `Space + th`               |
 | Vertical Split Terminal   | `Space + tv`               |

--- a/versioned_docs/version-2.6.0/Basic Usage/mappings.md
+++ b/versioned_docs/version-2.6.0/Basic Usage/mappings.md
@@ -121,7 +121,7 @@ title: Default Mappings
 
 | Action                    | Mappings                   |
 | ------------------------- | -------------------------- |
-| Toggle Terminal           | `F7`                       |
+| Toggle Terminal           | `F7`, `Ctrl + '`           |
 | Floating Terminal         | `Space + tf`               |
 | Horizontal Split Terminal | `Space + th`               |
 | Vertical Split Terminal   | `Space + tv`               |

--- a/versioned_docs/version-2.7.0/Basic Usage/mappings.md
+++ b/versioned_docs/version-2.7.0/Basic Usage/mappings.md
@@ -122,7 +122,7 @@ title: Default Mappings
 
 | Action                    | Mappings                   |
 | ------------------------- | -------------------------- |
-| Toggle Terminal           | `F7`                       |
+| Toggle Terminal           | `F7`, `Ctrl + '`           |
 | Floating Terminal         | `Space + tf`               |
 | Horizontal Split Terminal | `Space + th`               |
 | Vertical Split Terminal   | `Space + tv`               |

--- a/versioned_docs/version-2.8.0/Basic Usage/mappings.md
+++ b/versioned_docs/version-2.8.0/Basic Usage/mappings.md
@@ -122,7 +122,7 @@ title: Default Mappings
 
 | Action                    | Mappings                   |
 | ------------------------- | -------------------------- |
-| Toggle Terminal           | `F7`                       |
+| Toggle Terminal           | `F7`, `Ctrl + '`           |
 | Floating Terminal         | `Space + tf`               |
 | Horizontal Split Terminal | `Space + th`               |
 | Vertical Split Terminal   | `Space + tv`               |

--- a/versioned_docs/version-2.8.1/Basic Usage/mappings.md
+++ b/versioned_docs/version-2.8.1/Basic Usage/mappings.md
@@ -122,7 +122,7 @@ title: Default Mappings
 
 | Action                    | Mappings                   |
 | ------------------------- | -------------------------- |
-| Toggle Terminal           | `F7`                       |
+| Toggle Terminal           | `F7`, `Ctrl + '`           |
 | Floating Terminal         | `Space + tf`               |
 | Horizontal Split Terminal | `Space + th`               |
 | Vertical Split Terminal   | `Space + tv`               |

--- a/versioned_docs/version-2.9.0/Basic Usage/mappings.md
+++ b/versioned_docs/version-2.9.0/Basic Usage/mappings.md
@@ -140,7 +140,7 @@ title: Default Mappings
 
 | Action                    | Mappings                   |
 | ------------------------- | -------------------------- |
-| Toggle Terminal           | `F7`                       |
+| Toggle Terminal           | `F7`, `Ctrl + '`           |
 | Floating Terminal         | `Space + tf`               |
 | Horizontal Split Terminal | `Space + th`               |
 | Vertical Split Terminal   | `Space + tv`               |

--- a/versioned_docs/version-3.0.0/Basic Usage/mappings.md
+++ b/versioned_docs/version-3.0.0/Basic Usage/mappings.md
@@ -157,7 +157,7 @@ title: Default Mappings
 
 | Action                    | Mappings                     |
 | ------------------------- | ---------------------------- |
-| Toggle Terminal           | `F7`                         |
+| Toggle Terminal           | `F7`, `Ctrl + '`             |
 | Floating Terminal         | `Leader + tf`                |
 | Horizontal Split Terminal | `Leader + th`                |
 | Vertical Split Terminal   | `Leader + tv`                |

--- a/versioned_docs/version-3.10.0/Basic Usage/mappings.md
+++ b/versioned_docs/version-3.10.0/Basic Usage/mappings.md
@@ -157,7 +157,7 @@ title: Default Mappings
 
 | Action                    | Mappings                     |
 | ------------------------- | ---------------------------- |
-| Toggle Terminal           | `F7`                         |
+| Toggle Terminal           | `F7`, `Ctrl + '`             |
 | Floating Terminal         | `Leader + tf`                |
 | Horizontal Split Terminal | `Leader + th`                |
 | Vertical Split Terminal   | `Leader + tv`                |

--- a/versioned_docs/version-3.15.0/Basic Usage/mappings.md
+++ b/versioned_docs/version-3.15.0/Basic Usage/mappings.md
@@ -160,7 +160,7 @@ title: Default Mappings
 
 | Action                    | Mappings                     |
 | ------------------------- | ---------------------------- |
-| Toggle Terminal           | `F7`                         |
+| Toggle Terminal           | `F7`, `Ctrl + '`             |
 | Floating Terminal         | `Leader + tf`                |
 | Horizontal Split Terminal | `Leader + th`                |
 | Vertical Split Terminal   | `Leader + tv`                |

--- a/versioned_docs/version-3.2.0/Basic Usage/mappings.md
+++ b/versioned_docs/version-3.2.0/Basic Usage/mappings.md
@@ -157,7 +157,7 @@ title: Default Mappings
 
 | Action                    | Mappings                     |
 | ------------------------- | ---------------------------- |
-| Toggle Terminal           | `F7`                         |
+| Toggle Terminal           | `F7`, `Ctrl + '`             |
 | Floating Terminal         | `Leader + tf`                |
 | Horizontal Split Terminal | `Leader + th`                |
 | Vertical Split Terminal   | `Leader + tv`                |


### PR DESCRIPTION
I find the alternative Toggle Terminal mapping `Ctrl + '` in AstroNvim source code, which in my opinion is an easier mapping to use.
The latest 3.15.0 and nightly docs only mention `F7` so I suggest adding `Ctrl + '` to the mapping table.

There was a similar PR for 2.4.0 so I assume the keymap is valid since 2.4.0
https://github.com/AstroNvim/astronvim.github.io/pull/32