### PR TITLE
LSP references search hotkey documentation error?

### DIFF
--- a/docs/Basic Usage/mappings.md
+++ b/docs/Basic Usage/mappings.md
@@ -117,7 +117,7 @@ title: Default Mappings
 | Type Definition      | `gT`                |
 | Definition           | `gd`                |
 | Implementation       | `gI`                |
-| References           | `gr`                |
+| References           | `gr`, `Leader + lR` |
 
 ## Debugger Mappings
 


### PR DESCRIPTION
While I did not use the LSP type definition, definition, and implementation functions hotkeys yet, the references function, which supposedly searches through the code base to find lines that uses said function or class is not actually triggered by `gr`, but instead `lR`. Maybe the documentation is out of sync with the code changes?

Sorry for the small PR, as I do not understand those other functions enough to propose changes.