### PR TITLE
debugger shortcut mistake

### DIFF
--- a/versioned_docs/version-3.29.0/Basic Usage/walkthough.md
+++ b/versioned_docs/version-3.29.0/Basic Usage/walkthough.md
@@ -46,7 +46,7 @@ To use code actions you need to press `Space` + `la`
 
 ### Debugging
 
-To use the debugger you can press `Space` + `D` to see the available bindings and options
+To use the debugger you can press `Space` + `d` to see the available bindings and options
 
 ### Telescope search
 


### PR DESCRIPTION
pressing `space+D` deletes the line the cursor is currently on, while `space+d` actually brings up the debugger menu.

Hopefully this simple PR is not too much trouble.